### PR TITLE
BSC: UART as Serial abstraction and new d2, bt1, bt2, bt3 (#29)

### DIFF
--- a/apps/hello_world/src/main.rs
+++ b/apps/hello_world/src/main.rs
@@ -28,8 +28,9 @@ use logging::Logger;
 fn main() -> ! {
     let board = board::Mightybuga_BSC::take().unwrap();
     let mut delay = board.delay;
-    let mut uart = board.uart;
-    let mut led_d1 = board.leds.d1;
+    let mut uart = board.serial;
+    let mut led_d1 = board.led_d1;
+    let mut led_d2 = board.led_d2;
     let mut buzzer = board.buzzer;
     let mut engine = board.engine;
 
@@ -62,6 +63,14 @@ fn main() -> ! {
                 b'3' => {
                     // Turn off the LED D1
                     led_d1.set_low();
+                }
+                b'4' => {
+                    // Turn on the LED D1
+                    led_d2.set_high();
+                }
+                b'5' => {
+                    // Turn off the LED D1
+                    led_d2.set_low();
                 }
                 b'a' => {
                     // Move the robot forward
@@ -106,6 +115,8 @@ fn print_menu(logger: &mut Logger) {
     logger.log("   1. Play some notes with the buzzer\r\n");
     logger.log("   2. Turn on the LED D1\r\n");
     logger.log("   3. Turn off the LED D1\r\n");
+    logger.log("   4. Turn on the LED D2\r\n");
+    logger.log("   5. Turn off the LED D2\r\n");
     logger.log("   a. Move the robot forward\r\n");
     logger.log("   s. Move the robot backward\r\n");
     logger.log("   d. Turn the robot right\r\n");

--- a/mightybuga_bsc/Cargo.toml
+++ b/mightybuga_bsc/Cargo.toml
@@ -13,7 +13,7 @@ embedded-hal = "0.2.7"
 stm32f1xx-hal = { version = "0.10.0", features = ["rt", "stm32f103", "medium"] }
 cortex-m-semihosting = "0.5.0"
 panic-halt = "0.2.0"
-# panic-semihosting = "0.6.0"
+panic-semihosting = "0.6.0"
 
 timer_based_buzzer_interface = { path = "../libs/timer_based_buzzer_interface/" }
 

--- a/mightybuga_bsc/examples/blink.rs
+++ b/mightybuga_bsc/examples/blink.rs
@@ -14,12 +14,15 @@ use mightybuga_bsc as board;
 fn main() -> ! {
     let board = board::Mightybuga_BSC::take().unwrap();
     let mut delay = board.delay;
-    let mut led_d1 = board.leds.d1;
+    let mut led_d1 = board.led_d1;
+    let mut led_d2 = board.led_d2;
 
     loop {
         delay.delay(200.millis());
         led_d1.set_high();
+        led_d2.set_low();
         delay.delay_ms(100_u16);
         led_d1.set_low();
+        led_d2.set_high();
     }
 }

--- a/mightybuga_bsc/examples/buzzer.rs
+++ b/mightybuga_bsc/examples/buzzer.rs
@@ -16,7 +16,7 @@ use mightybuga_bsc::timer_based_buzzer::TimerBasedBuzzerInterface;
 fn main() -> ! {
     let board = board::Mightybuga_BSC::take().unwrap();
     let mut delay = board.delay;
-    let mut led_d1 = board.leds.d1;
+    let mut led_d1 = board.led_d1;
     let mut buzzer = board.buzzer;
 
     // loop only three times to avoid annoying the user

--- a/mightybuga_bsc/examples/engine.rs
+++ b/mightybuga_bsc/examples/engine.rs
@@ -16,7 +16,7 @@ use engine::engine::EngineController;
 fn main() -> ! {
     let board = board::Mightybuga_BSC::take().unwrap();
     let mut delay = board.delay;
-    let mut led_d1 = board.leds.d1;
+    let mut led_d1 = board.led_d1;
     let mut engine = board.engine;
 
     engine.forward(u16::MAX / 4);

--- a/mightybuga_bsc/examples/uart_echo.rs
+++ b/mightybuga_bsc/examples/uart_echo.rs
@@ -17,8 +17,8 @@ use nb::block;
 fn main() -> ! {
     let board = board::Mightybuga_BSC::take().unwrap();
     let mut delay = board.delay;
-    let mut uart = board.uart;
-    let mut led_d1 = board.leds.d1;
+    let mut uart = board.serial;
+    let mut led_d1 = board.led_d1;
 
     let s = b"\r\nPlease type characters to echo:\r\n";
     let _ = s.iter().map(|c| block!(uart.tx.write(*c))).last();

--- a/mightybuga_bsc/openocd.cfg
+++ b/mightybuga_bsc/openocd.cfg
@@ -13,6 +13,6 @@ set CPUTAPID 0x1ba01477
 # source [find interface/stlink-v2-1.cfg]
 
 # Revision A and B (older revisions)
-source [find interface/stlink-v2.cfg]
+source [find interface/stlink.cfg]
 
 source [find target/stm32f1x.cfg]

--- a/mightybuga_bsc/src/lib.rs
+++ b/mightybuga_bsc/src/lib.rs
@@ -26,21 +26,17 @@ pub mod prelude {
     };
 }
 
-pub struct UART {
-    pub rx: Rx<USART1>,
-    pub tx: Tx<USART1>,
-}
-pub struct Leds {
-    pub d1: gpio::Pin<'C', 13, gpio::Output>,
-}
-
 pub struct Mightybuga_BSC {
+    // LEDs
+    pub led_d1: gpio::Pin<'C', 13, gpio::Output>,
+    pub led_d2: gpio::Pin<'B', 12, gpio::Output>,
+    // UART
+    pub serial: Serial<
+        USART1, 
+        (gpio::Pin<'A',9, gpio::Alternate>, gpio::Pin<'A', 10, gpio::Input>),
+        >,
     // delay provider
     pub delay: SysDelay,
-    // UART
-    pub uart: UART,
-    // LEDs
-    pub leds: Leds,
     // Buzzer
     pub buzzer: TimerBasedBuzzer,
     // Engine
@@ -85,27 +81,26 @@ impl Mightybuga_BSC {
 
         let mut afio = dp.AFIO.constrain();
 
-        // Serial port configuration
+        // GPIO ports
         let mut gpioa = dp.GPIOA.split();
-        let tx = gpioa.pa9.into_alternate_push_pull(&mut gpioa.crh);
-        let rx = gpioa.pa10;
-        let serial = Serial::new(
+        let mut gpiob = dp.GPIOB.split();
+        let mut gpioc = dp.GPIOC.split();
+
+        // LEDs configuration
+        let d1 = gpioc.pc13.into_push_pull_output(&mut gpioc.crh);
+        let d2 = gpiob.pb12.into_push_pull_output(&mut gpiob.crh);
+
+        // Serial port configuration
+        let serial_uart = Serial::new(
             dp.USART1,
-            (tx, rx),
+            (
+                gpioa.pa9.into_alternate_push_pull(&mut gpioa.crh),
+                gpioa.pa10.into_floating_input(&mut gpioa.crh),
+            ),
             &mut afio.mapr,
-            Config::default()
-                .baudrate(115_200.bps())
-                .wordlength_8bits()
-                .parity_none(),
+            Config::default().baudrate(115_200.bps()),
             &clocks,
         );
-        let (tx, rx) = serial.split();
-
-        // LED configuration
-        let mut gpioc = dp.GPIOC.split();
-        let d1: gpio::Pin<'C', 13, gpio::Output> = gpioc.pc13.into_push_pull_output(&mut gpioc.crh);
-
-        let mut gpiob = dp.GPIOB.split();
 
         // Engine/Motors configuration (PWM)
         let pwm_motor_pins = (
@@ -150,9 +145,10 @@ impl Mightybuga_BSC {
         // Return the initialized struct
 
         Ok(Mightybuga_BSC {
+            led_d1: d1,
+            led_d2: d2,
+            serial: serial_uart,
             delay,
-            uart: UART { rx, tx },
-            leds: Leds { d1 },
             buzzer,
             engine,
         })


### PR DESCRIPTION
* Remove openocd warning: interface/stlink-v2.cfg is deprecated

* BSC: UART as Serial abstraction and new d2, bt1, bt2, bt3

* Hardware test for LED D2

* Button gpios where removed in favour of the issue #30