### PR TITLE
Upload tools refactor and BMP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,37 +32,39 @@ tar -xf gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2 -C /home/$USER/arm-g
 cargo doc --open
 ```
 
-## Flashing
+## Upload the firmware to the MCU
+
 ```commandline
 cargo xtask mightybuga_bsc example blink # use 'cargo xtask help' for a complete list of options
 ```
 
+Set the environment variable *UPLOAD_TOOL* (default is `openocd`) to use your prefered tool for uploading the firmware to the flash memory of the MCU:
+
+| tools | *UPLOAD_TOOL* | notes |
+|-------|---------------|-------|
+| OpenOCD + STLink-v2 probe | openocd | This is the default. |
+| BlackMagicProbe | blackmagic | *BMP_PORT* variable to set the device where the BMP is connected (default is `/dev/ttyACM0`). |
+
+Example to use BMP:
+
+```sh
+export UPLOAD_TOOL=blackmagic
+cargo xtask run app hello_world
+```
+
 ### Use GDB debug
+
 You need `runner = "gdb-multiarch -q -x openocd_debug.gdb"` in mightybuga_bsc/.cargo/config , then start a openocd instance:
+
 ```commandline
 sudo openocd -f openocd.cfg
 ```
+
 and:
+
 ```commandline
 cargo run
 ```
-### Just use openocd to flash the binary:
-You need `runner = "./flash.sh"` and:
-```commandline
-cargo run
-```
-
-### Unexpected idcode
-The idcode refers to the chip identification. Real STM32F103C8T6s has idcode `0x2ba01477`, the CS32F103C8T6 clone has `0x1ba0147`. If openOCD exits with an error like this:
-```
-Warn : UNEXPECTED idcode: 0x1ba01477
-Error: expected 1 of 1: 0x2ba01477
-```
-Update your chip id in openocd.cfg
-
-References:
- - https://www.eevblog.com/forum/beginners/unexpected-idcode-flashing-bluepill-clone/
- - https://community.platformio.org/t/debugging-of-stm32f103-clone-bluepill-board-wrong-idcode/14635
 
 ## References
 Forked from https://cgit.pinealservo.com/BluePill_Rust/blue_pill_base

--- a/apps/hello_world/.cargo/config
+++ b/apps/hello_world/.cargo/config
@@ -4,7 +4,9 @@
 # runner = "arm-none-eabi-gdb -q -x openocd.gdb"
 #runner = "gdb-multiarch -q -x openocd.gdb"
 #runner = "gdb-multiarch -q -x openocd_just_flash_and_run.gdb"
-runner = "./flash.sh"
+#runner = "./flash.sh"
+
+runner = "../../tools/upload.sh"
 
 rustflags = [
   # LLD (shipped with the Rust toolchain) is used as the default linker

--- a/apps/hello_world/.gdbinit
+++ b/apps/hello_world/.gdbinit
@@ -1,4 +1,0 @@
-target remote :3333
-
-load
-step

--- a/libs/hal_button/Cargo.toml
+++ b/libs/hal_button/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Rafa Couto <caligari@treboada.net>"]
 edition = "2021"
 
 [dependencies]
-embedded-hal = "0.2.4"
+embedded-hal = "0.2.7"

--- a/libs/hal_button/Cargo.toml
+++ b/libs/hal_button/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Rafa Couto <caligari@treboada.net>"]
 edition = "2021"
 
 [dependencies]
-embedded-hal = "0.2.7"
+embedded-hal = { version = "0.2.7", features = ["unproven"] }

--- a/mightybuga_bsc/.cargo/config
+++ b/mightybuga_bsc/.cargo/config
@@ -5,7 +5,9 @@
 #runner = "gdb-multiarch -q -x openocd_debug.gdb"
 
 # Option to flash the program onto the board using just OpenOCD
-runner = "./flash.sh"
+#runner = "./flash.sh"
+
+runner = "../tools/upload.sh"
 
 rustflags = [
   # LLD (shipped with the Rust toolchain) is used as the default linker

--- a/mightybuga_bsc/examples/no_bsc_blink_semihosting.rs
+++ b/mightybuga_bsc/examples/no_bsc_blink_semihosting.rs
@@ -8,8 +8,6 @@
 #![no_std]
 #![cfg_attr(not(doc), no_main)]
 
-use panic_semihosting as _; // need to enable panic_semihosting in Cargo.toml
-
 use core::fmt::Write;
 // Note that Semihosting needs somebody listening (STLink). If you program this code with
 // semihosting and reset it without an OpenOCD listening the program will halt on the first

--- a/mightybuga_bsc/flash.sh
+++ b/mightybuga_bsc/flash.sh
@@ -1,7 +1,0 @@
-# Uses openocd to flash the firmware.
-# This script is used from `cargo run` when used the apropiate option in .cargo/config (parameter: runner)
-
-echo "Flashing $1"
-
-killall openocd
-openocd -f openocd.cfg -c init -c halt -c "flash write_image erase $1" -c reset  -c shutdown

--- a/mightybuga_bsc/flash_semihosting.sh
+++ b/mightybuga_bsc/flash_semihosting.sh
@@ -1,7 +1,0 @@
-# Uses openocd to flash the firmware.
-# This script is used from `cargo run` when used the apropiate option in .cargo/config (parameter: runner)
-
-echo "Flashing $1"
-
-killall openocd
-openocd -f openocd.cfg -c init -c halt -c "arm semihosting enable" -c "flash write_image erase $1" -c reset # -c shutdown

--- a/tools/blackmagic/gdb-functions
+++ b/tools/blackmagic/gdb-functions
@@ -1,0 +1,16 @@
+
+# This user-defined function flashes the given .elf 
+# file to the microcontroller and should then  exit.
+# $arg0 is the .elf file to flash
+# $arg1 is the com port to use
+define upload-remote
+  target extended-remote $arg1
+  monitor version
+  monitor swdp_scan
+  attach 1
+  file $arg0
+  load
+  start
+  detach
+  quit
+end

--- a/tools/blackmagic/upload.sh
+++ b/tools/blackmagic/upload.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+echo "Uploading $1 with blackmagic probe"
+
+# Default port is /dev/ttyACM0 or the second argument
+BMP_PORT=${2:-/dev/ttyACM0}
+
+# Check if gdb-multiarch is installed
+GDB=$(command -v gdb-multiarch)
+if [ -z "$GDB" ]; then
+    echo "gdb-multiarch not found. Please install it."
+    exit 1
+fi
+
+gdb-multiarch -n -batch \
+    -x ${TOOLS_DIR}/blackmagic/gdb-functions \
+    -ex "upload-remote $1 $BMP_PORT"

--- a/tools/openocd/.gdbinit
+++ b/tools/openocd/.gdbinit
@@ -1,4 +1,3 @@
 target remote :3333
-
 load
 step

--- a/tools/openocd/debug.sh
+++ b/tools/openocd/debug.sh
@@ -1,0 +1,10 @@
+echo "Debugging $1"
+
+# kill any openocd instances
+killall openocd
+
+openocd -f ${TOOLS_DIR}/openocd/stlink-stm32f1.cfg \
+    -c init -c halt \
+    -c "arm semihosting enable" \
+    -c "flash write_image erase $1" \
+    -c reset

--- a/tools/openocd/stlink-stm32f1.cfg
+++ b/tools/openocd/stlink-stm32f1.cfg
@@ -1,0 +1,3 @@
+
+source [find interface/stlink.cfg]
+source [find target/stm32f1x.cfg]

--- a/tools/openocd/upload.sh
+++ b/tools/openocd/upload.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "Uploading $1 with openocd and stlink probe"
+
+openocd -f ${TOOLS_DIR}/openocd/stlink-stm32f1.cfg \
+    -c init -c halt \
+    -c "flash write_image erase $1" \
+    -c reset -c shutdown

--- a/tools/upload.sh
+++ b/tools/upload.sh
@@ -4,23 +4,23 @@
 # It is used from `cargo run` when used the apropiate option in .cargo/config (parameter: runner)
 
 # Set the upload programming probe to use
-UPLOAD_PROBE=${UPLOAD_PROBE:-"openocd"}
+UPLOAD_TOOL=${UPLOAD_TOOL:-'openocd'}
 
 # set this script directory as the reference directory for relative paths
 export TOOLS_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
-case $UPLOAD_PROBE in
+case ${UPLOAD_TOOL} in
 
-    "openocd")
+    'openocd')
         ${TOOLS_DIR}/openocd/upload.sh $1
         ;;
 
-    "blackmagic")
+    'blackmagic')
         ${TOOLS_DIR}/blackmagic/upload.sh $1
         ;;
 
     *)
-        echo "Unknown upload probe: $UPLOAD_PROBE"
+        echo "Unknown upload tool: ${UPLOAD_TOOL}"
         exit 1
         ;;
 esac

--- a/tools/upload.sh
+++ b/tools/upload.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# This script is used to upload the firmware to the board.
+# It is used from `cargo run` when used the apropiate option in .cargo/config (parameter: runner)
+
+# Set the upload programming probe to use
+UPLOAD_PROBE=${UPLOAD_PROBE:-"openocd"}
+
+# set this script directory as the reference directory for relative paths
+export TOOLS_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+case $UPLOAD_PROBE in
+
+    "openocd")
+        ${TOOLS_DIR}/openocd/upload.sh $1
+        ;;
+
+    "blackmagic")
+        ${TOOLS_DIR}/blackmagic/upload.sh $1
+        ;;
+
+    *)
+        echo "Unknown upload probe: $UPLOAD_PROBE"
+        exit 1
+        ;;
+esac
+


### PR DESCRIPTION
- Refactor to join openocd scripts and config under `/tools/openocd` directory
- Added new directory `/tools/blackmagic` to upload firmware with *BlackMagicProbe*
- Documentation in README.md explaining how to upload firmware
- Bugfix: removed `panic_semihosting` refered crate on the *blink* example