### PR TITLE
Hotfix: wrong embedded-hal dependency version in hal_button

### DIFF
--- a/libs/hal_button/Cargo.toml
+++ b/libs/hal_button/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Rafa Couto <caligari@treboada.net>"]
 edition = "2021"
 
 [dependencies]
-embedded-hal = "0.2.4"
+embedded-hal = "0.2.7"

--- a/libs/hal_button/Cargo.toml
+++ b/libs/hal_button/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Rafa Couto <caligari@treboada.net>"]
 edition = "2021"
 
 [dependencies]
-embedded-hal = "0.2.7"
+embedded-hal = { version = "0.2.7", features = ["unproven"] }


### PR DESCRIPTION
This change fix the version of the _embedded-hal_ dependency in the crate _hal_button_ to the same one as used in the whole project.