### PR TITLE
Allow the ADC1 to be shared by multiple structs or methods

### DIFF
--- a/mightybuga_bsc/src/lib.rs
+++ b/mightybuga_bsc/src/lib.rs
@@ -1,16 +1,18 @@
 #![no_std]
 #![allow(non_camel_case_types)]
 
-use hal::gpio::PullDown;
 // reexport hal crates to allow users to directly refer to them
 // like in https://github.com/therealprof/nucleo-f103rb/blob/master/src/lib.rs
 pub use stm32f1xx_hal as hal;
 
 use hal::adc::Adc;
 use hal::pac::*;
+use hal::gpio::PullDown;
 use hal::prelude::*;
 use hal::serial::*;
 use hal::timer::SysDelay;
+
+use core::cell::RefCell;
 
 use engine::engine::Engine;
 use engine::motor::Motor;
@@ -173,7 +175,7 @@ impl Mightybuga_BSC {
             sensor_5: gpioa.pa5.into_analog(&mut gpioa.crl),
             sensor_6: gpioa.pa6.into_analog(&mut gpioa.crl),
             sensor_7: gpioa.pa7.into_analog(&mut gpioa.crl),
-            adc: adc1,
+            adc: RefCell::new(adc1),
         };
 
         // Return the initialized struct
@@ -186,9 +188,9 @@ impl Mightybuga_BSC {
             delay,
             buzzer,
             engine,
-            btn_1: btn_1,
-            btn_2: btn_2,
-            btn_3: btn_3,
+            btn_1,
+            btn_2,
+            btn_3,
             light_sensor_array,
         })
     }

--- a/mightybuga_bsc/src/lib.rs
+++ b/mightybuga_bsc/src/lib.rs
@@ -179,8 +179,6 @@ impl Mightybuga_BSC {
         };
 
         // Return the initialized struct
-
-        // Return the initialized struct
         Ok(Mightybuga_BSC {
             led_d1: d1,
             led_d2: d2,

--- a/mightybuga_bsc/src/light_sensor_array.rs
+++ b/mightybuga_bsc/src/light_sensor_array.rs
@@ -1,3 +1,4 @@
+use core::cell::RefCell;
 use crate::hal::{
     adc::Adc,
     gpio::{Analog, Output, Pin},
@@ -22,20 +23,20 @@ pub struct LightSensorArray {
     pub sensor_6: Pin<'A', 6, Analog>,
     pub sensor_7: Pin<'A', 7, Analog>,
 
-    pub adc: Adc<ADC1>,
+    pub adc: RefCell<Adc<ADC1>>,
 }
 
 impl light_sensor_array_controller::LightSensorArrayController for LightSensorArray {
     fn get_light_map(&mut self) -> [u16; 8] {
         let light_map = [
-            self.adc.read(&mut self.sensor_0).unwrap(),
-            self.adc.read(&mut self.sensor_1).unwrap(),
-            self.adc.read(&mut self.sensor_2).unwrap(),
-            self.adc.read(&mut self.sensor_3).unwrap(),
-            self.adc.read(&mut self.sensor_4).unwrap(),
-            self.adc.read(&mut self.sensor_5).unwrap(),
-            self.adc.read(&mut self.sensor_6).unwrap(),
-            self.adc.read(&mut self.sensor_7).unwrap(),
+            self.adc.get_mut().read(&mut self.sensor_0).unwrap(),
+            self.adc.get_mut().read(&mut self.sensor_1).unwrap(),
+            self.adc.get_mut().read(&mut self.sensor_2).unwrap(),
+            self.adc.get_mut().read(&mut self.sensor_3).unwrap(),
+            self.adc.get_mut().read(&mut self.sensor_4).unwrap(),
+            self.adc.get_mut().read(&mut self.sensor_5).unwrap(),
+            self.adc.get_mut().read(&mut self.sensor_6).unwrap(),
+            self.adc.get_mut().read(&mut self.sensor_7).unwrap(),
         ];
 
         light_map


### PR DESCRIPTION
The LightSensorArray struct now uses a RefCell to the ADC1 instead of borrowing its value, which can allow us to use it for other purposes such as the battery sensor.