### PR TITLE
Made it possible to share the ADC

### DIFF
--- a/mightybuga_bsc/Cargo.toml
+++ b/mightybuga_bsc/Cargo.toml
@@ -14,6 +14,7 @@ stm32f1xx-hal = { version = "0.10.0", features = ["rt", "stm32f103", "medium"] }
 cortex-m-semihosting = "0.5.0"
 panic-halt = "0.2.0"
 panic-semihosting = "0.6.0"
+heapless = { version = "0.8.0", features = ["portable-atomic"] }
 
 fugit = "0.3.7"
 

--- a/mightybuga_bsc/examples/no_bsc_arc.rs
+++ b/mightybuga_bsc/examples/no_bsc_arc.rs
@@ -3,6 +3,7 @@
 //! safe way (except for the part in which we define the block of memory, that requires using unsafe)
 #![no_std]
 #![cfg_attr(not(doc), no_main)]
+#![allow(static_mut_refs)]
 use core::cell::RefCell;
 
 use stm32f1xx_hal::{

--- a/mightybuga_bsc/examples/no_bsc_arc.rs
+++ b/mightybuga_bsc/examples/no_bsc_arc.rs
@@ -1,0 +1,55 @@
+#![no_std]
+#![cfg_attr(not(doc), no_main)]
+use core::cell::RefCell;
+
+use stm32f1xx_hal::{
+    pac::ADC1,
+    adc::Adc,
+};
+
+use panic_halt as _;
+
+use mightybuga_bsc as board;
+
+use cortex_m_rt::entry;
+use board::hal::{pac, prelude::*};
+
+use heapless::arc_pool;
+
+#[entry]
+fn main() -> ! {
+    // Get access to the core peripherals from the cortex-m crate
+    let _cp = cortex_m::Peripherals::take().unwrap();
+    // Get access to the device specific peripherals from the peripheral access crate
+    let dp = pac::Peripherals::take().unwrap();
+
+    // Take ownership over the raw flash and rcc devices and convert them into the corresponding
+    // HAL structs
+    let mut flash = dp.FLASH.constrain();
+    let rcc = dp.RCC.constrain();
+
+    // Freeze the configuration of all the clocks in the system and store the frozen frequencies in
+    // `clocks`
+    let clocks = rcc.cfgr.freeze(&mut flash.acr);
+
+    // Acquire the GPIOC peripheral
+    let _gpioc = dp.GPIOC.split();
+
+    arc_pool!(P: RefCell<Adc<ADC1>>);
+
+    let arc = match P.alloc(RefCell::new(Adc::adc1(dp.ADC1, clocks))) {
+        Ok(adc_arc) => adc_arc,
+        Err(_) => panic!("Couldn't get the adc arc"),
+    };
+    let arc2 = arc.clone();
+
+    let mut gpioa = dp.GPIOA.split();
+    let _x: u16 = arc2.borrow_mut().read(&mut gpioa.pa0.into_analog(&mut gpioa.crl)).unwrap();
+
+    drop(arc2);
+    drop(arc);
+
+    loop {
+
+    }
+}

--- a/mightybuga_bsc/examples/no_bsc_arc.rs
+++ b/mightybuga_bsc/examples/no_bsc_arc.rs
@@ -1,3 +1,6 @@
+//! This is an example on how to use the `Arc` type from the `heapless` crate to allocate something
+//! in the memory and then create pointers to that location in order to use it in a memory
+//! safe way (except for the part in which we define the block of memory, that requires using unsafe)
 #![no_std]
 #![cfg_attr(not(doc), no_main)]
 use core::cell::RefCell;
@@ -14,7 +17,10 @@ use mightybuga_bsc as board;
 use cortex_m_rt::entry;
 use board::hal::{pac, prelude::*};
 
-use heapless::arc_pool;
+use heapless::{
+    arc_pool,
+    pool::arc::ArcBlock,
+};
 
 #[entry]
 fn main() -> ! {
@@ -34,18 +40,39 @@ fn main() -> ! {
 
     // Acquire the GPIOC peripheral
     let _gpioc = dp.GPIOC.split();
+    let mut gpioa = dp.GPIOA.split();
 
+    // This macro generates all the necessary code implementations to allocate a refcell containing
+    // the adc1 into a block in the memory
     arc_pool!(P: RefCell<Adc<ADC1>>);
 
+    // Generate the memory block in which the refcell<adc1> will be allocated, we need to do
+    // this in an unsafe way
+    let arc_block: &'static mut ArcBlock<RefCell<Adc<ADC1>>> = unsafe {
+        static mut B: ArcBlock<RefCell<Adc<ADC1>>> = ArcBlock::new();
+        &mut B
+    };
+
+    // Tell the singleton to use this block in the memory for managing the refcell<adc1>
+    P.manage(arc_block);
+
+    // Allocate the adc1 inside of a refcell in the memory block we created earlier, the `alloc`
+    // method doesn't have an unwrap for its Result, so we use a simple match statement to do that.
     let arc = match P.alloc(RefCell::new(Adc::adc1(dp.ADC1, clocks))) {
         Ok(adc_arc) => adc_arc,
-        Err(_) => panic!("Couldn't get the adc arc"),
+        Err(_) => {
+            panic!("Couldn't get the Arc");
+        },
     };
+
+    // Clone the pointer to the refcell<adc1>
     let arc2 = arc.clone();
 
-    let mut gpioa = dp.GPIOA.split();
+    // Use any of those pointers to read using the adc
     let _x: u16 = arc2.borrow_mut().read(&mut gpioa.pa0.into_analog(&mut gpioa.crl)).unwrap();
+    let _y: u16 = arc.borrow_mut().read(&mut gpioa.pa2.into_analog(&mut gpioa.crl)).unwrap();
 
+    // Drop the pointers and the original instance of the refcell<adc1>
     drop(arc2);
     drop(arc);
 

--- a/mightybuga_bsc/src/lib.rs
+++ b/mightybuga_bsc/src/lib.rs
@@ -14,7 +14,10 @@ use hal::timer::SysDelay;
 
 use core::cell::RefCell;
 
-use heapless::arc_pool;
+use heapless::{
+    arc_pool,
+    pool::arc::ArcBlock,
+};
 use core::ops::Deref;
 
 use engine::engine::Engine;
@@ -189,6 +192,13 @@ impl Mightybuga_BSC {
             TimerChannels::Ch1Ch2,
             EncoderPolarity::PolarityBA,
         );
+
+        // Generate the memory block in which the adc will be allocated
+        let adc_arc_block: &'static mut ArcBlock<RefCell<Adc<ADC1>>> = unsafe {
+            static mut B: ArcBlock<RefCell<Adc<ADC1>>> = ArcBlock::new();
+            &mut B
+        };
+        ADC_POOL.manage(adc_arc_block);
 
         // Allocate the Adc in an Arc to share it
         let adc_arc = match ADC_POOL.alloc(RefCell::new(Adc::adc1(dp.ADC1, clocks))) {

--- a/mightybuga_bsc/src/lib.rs
+++ b/mightybuga_bsc/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![allow(non_camel_case_types)]
+#![allow(static_mut_refs)]
 
 // reexport hal crates to allow users to directly refer to them
 // like in https://github.com/therealprof/nucleo-f103rb/blob/master/src/lib.rs

--- a/mightybuga_bsc/src/light_sensor_array.rs
+++ b/mightybuga_bsc/src/light_sensor_array.rs
@@ -1,9 +1,10 @@
-use core::cell::RefCell;
-use crate::hal::{
-    adc::Adc,
-    gpio::{Analog, Output, Pin},
-    pac::ADC1,
-    prelude::_embedded_hal_adc_OneShot,
+use heapless::pool::arc::Arc;
+use crate::{
+    hal::{
+        gpio::{Analog, Output, Pin},
+        prelude::_embedded_hal_adc_OneShot,
+    },
+    ADC_POOL,
 };
 
 /// The LineSensor used to detect the place where the line is located.
@@ -23,20 +24,23 @@ pub struct LightSensorArray {
     pub sensor_6: Pin<'A', 6, Analog>,
     pub sensor_7: Pin<'A', 7, Analog>,
 
-    pub adc: RefCell<Adc<ADC1>>,
+    pub adc: Arc<ADC_POOL>,
 }
 
 impl light_sensor_array_controller::LightSensorArrayController for LightSensorArray {
     fn get_light_map(&mut self) -> [u16; 8] {
+
+        let mut adc = self.adc.borrow_mut();
+
         let light_map = [
-            self.adc.get_mut().read(&mut self.sensor_0).unwrap(),
-            self.adc.get_mut().read(&mut self.sensor_1).unwrap(),
-            self.adc.get_mut().read(&mut self.sensor_2).unwrap(),
-            self.adc.get_mut().read(&mut self.sensor_3).unwrap(),
-            self.adc.get_mut().read(&mut self.sensor_4).unwrap(),
-            self.adc.get_mut().read(&mut self.sensor_5).unwrap(),
-            self.adc.get_mut().read(&mut self.sensor_6).unwrap(),
-            self.adc.get_mut().read(&mut self.sensor_7).unwrap(),
+            adc.read(&mut self.sensor_0).unwrap(),
+            adc.read(&mut self.sensor_1).unwrap(),
+            adc.read(&mut self.sensor_2).unwrap(),
+            adc.read(&mut self.sensor_3).unwrap(),
+            adc.read(&mut self.sensor_4).unwrap(),
+            adc.read(&mut self.sensor_5).unwrap(),
+            adc.read(&mut self.sensor_6).unwrap(),
+            adc.read(&mut self.sensor_7).unwrap(),
         ];
 
         light_map


### PR DESCRIPTION
Added the `heapless` crate as a dependency to use the ADC inside of an `Arc` that can be cloned and used by multiple structs. This makes it possible for 2 different structs, like the light sensor array and the future battery sensor, to use the ADC1.

This pull request also adds a small example of how to use `Arc` with the ADC.