### PR TITLE
Corrected a few errors in the GDB config files.

### DIFF
--- a/apps/hello_world/.cargo/config
+++ b/apps/hello_world/.cargo/config
@@ -1,9 +1,10 @@
 [target.thumbv7m-none-eabi]
 # uncomment ONE of these three option to make `cargo run` start a GDB session
 # which option to pick depends on your system
-# runner = "arm-none-eabi-gdb -q -x openocd.gdb"
-#runner = "gdb-multiarch -q -x openocd.gdb"
+#runner = "arm-none-eabi-gdb -q -x openocd.gdb"
+#runner = "gdb-multiarch -q -x openocd_debug.gdb"
 #runner = "gdb-multiarch -q -x openocd_just_flash_and_run.gdb"
+
 #runner = "./flash.sh"
 
 runner = "../../tools/upload.sh"

--- a/apps/hello_world/openocd.cfg
+++ b/apps/hello_world/openocd.cfg
@@ -13,6 +13,6 @@ set CPUTAPID 0x1ba01477
 # source [find interface/stlink-v2-1.cfg]
 
 # Revision A and B (older revisions)
-source [find interface/stlink-v2.cfg]
+source [find interface/stlink.cfg]
 
 source [find target/stm32f1x.cfg]


### PR DESCRIPTION
There were a few problems with the gdb config files:
- In the `.cargo/config` it was trying to open a file `openocd.gdb` instead of the existing `openocd_debug.gdb`
- In `openocd.cfg` it was trying to use `interface/stlink-v2.cfg`, which is deprecated and now uses `interface/stlink.cfg`

The other "problem" I had is that gdb runs the program without stopping in breakpoints or similar, but i assume that's something normal in embedded environments.

I didn't have any other issues  so I think we could close #40 (Maybe create a markdown file in `docs` for GDB before doing it, so that the instructions are not in the READMEs)