### PR TITLE
Move the GDB guide to the docs directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,19 +52,8 @@ export UPLOAD_TOOL=blackmagic
 cargo xtask run app hello_world
 ```
 
-### Use GDB debug
-
-You need `runner = "gdb-multiarch -q -x openocd_debug.gdb"` in mightybuga_bsc/.cargo/config , then start a openocd instance:
-
-```commandline
-sudo openocd -f openocd.cfg
-```
-
-and:
-
-```commandline
-cargo run
-```
+## Debugging
+Go to the [documentation for debugging](./docs/GDB_Debugging/gdb-debugging.md).
 
 ## References
 Forked from https://cgit.pinealservo.com/BluePill_Rust/blue_pill_base

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ cargo xtask run app hello_world
 ```
 
 ## Debugging
-Go to the [documentation for debugging](./docs/GDB_Debugging/gdb-debugging.md).
+Go to the [documentation for debugging](./docs/GDB-Debugging/gdb-debugging.md).
 
 ## References
 Forked from https://cgit.pinealservo.com/BluePill_Rust/blue_pill_base

--- a/docs/GDB-Debugging/gdb-debugging.md
+++ b/docs/GDB-Debugging/gdb-debugging.md
@@ -1,0 +1,24 @@
+# GDB Debug
+
+You need the line
+
+```
+runner = "gdb-multiarch -q -x openocd_debug.gdb"
+```
+
+in `mightybuga_bsc/.cargo/config` or `apps/{APP_NAME}/.cargo/config`.
+
+Then start a openocd instance (from the directory of an app or `mightybuga_bsc`):
+
+```bash
+sudo openocd -f openocd.cfg
+```
+
+and in the app's directory:
+
+```bash
+cargo run
+```
+
+or you can use an `xtask` command to debug an example.
+

--- a/mightybuga_bsc/README.md
+++ b/mightybuga_bsc/README.md
@@ -18,14 +18,6 @@ cargo xtask mightybuga_bsc example blink # use 'cargo xtask help' for a complete
 ```
 or from the BSC folder:
 
+## Debugging
+Go to the [documentation for debugging](../docs/GDB-Debugging/gdb-debugging.md).
 
-### Debugging
-Check what runner you have uncommented in .cargo/config:
-
-You need `runner = "gdb-multiarch -q -x openocd.gdb", start a openocd instance:
-
-sudo openocd -f openocd.cfg
-
-and:
-
-cargo xtask mightybuga_bsc example blink


### PR DESCRIPTION
I thought it could be good to have the gdb documentation in a single place.
Moves the GDB Debugging guide to a file in the `docs` directory and leaves a link in the READMEs. 