### PR TITLE
Added logging methods for u16 and u16 array

### DIFF
--- a/libs/logging/src/lib.rs
+++ b/libs/logging/src/lib.rs
@@ -29,12 +29,12 @@ impl<'a> Logger<'a> {
     pub fn log_u16(&mut self, val: &u16) {
         for digit_index in (1..6).rev() {
 
-            // We have to temporarily convert the u16 to u32, otherwise doing 10^5 would cause an
+            // We have to temporarily the u16 to u32, otherwise doing 10^5 would cause an
             // overflow in a u16 (100,000 > 65,535)
-            let digit = ((*val as u32 % 10u32.pow(digit_index as u32)) / 10u32.pow(digit_index as u32 - 1)) as u16;
-            let digit_character = digit + 48; // 48 is the offset of the numbers in the ASCII table
+            let digit = (*val as u32 % 10u32.pow(digit_index as u32)) / 10u32.pow(digit_index as u32 - 1);
+            let digit_character: u8 = digit as u8 + 48; // 48 is the offset of the numbers in the ASCII table
 
-            block!(match self.uart.bwrite_all(&[digit_character as u8]) {
+            block!(match self.uart.bwrite_all(&[digit_character]) {
                 Ok(_) => Ok(()),
                 Err(_) => Err(nb::Error::Other(())),
             })

--- a/libs/logging/src/lib.rs
+++ b/libs/logging/src/lib.rs
@@ -29,7 +29,7 @@ impl<'a> Logger<'a> {
     pub fn log_u16(&mut self, val: &u16) {
         for digit_index in (1..6).rev() {
 
-            // We have to temporarily convert the u16 to u32, otherwise doing 10⁶5 would cause an
+            // We have to temporarily convert the u16 to u32, otherwise doing 10^5 would cause an
             // overflow in a u16 (100,000 > 65,535)
             let digit = ((*val as u32 % 10u32.pow(digit_index as u32)) / 10u32.pow(digit_index as u32 - 1)) as u16;
             let digit_character = digit + 48; // 48 is the offset of the numbers in the ASCII table
@@ -107,5 +107,21 @@ mod tests {
         let mut logger = Logger::new(&mut mock_writer);
         logger.log("Hello");
         assert_eq!(mock_writer.get_string(), "Hello");
+    }
+
+    #[test]
+    fn test_log_u16() {
+        let mut mock_writer = MockWriter::new();
+        let mut logger = Logger::new(&mut mock_writer);
+        logger.log_u16(&3456u16);
+        assert_eq!(mock_writer.get_string(), "03456");
+    }
+
+    #[test]
+    fn test_log_u16_array() {
+        let mut mock_writer = MockWriter::new();
+        let mut logger = Logger::new(&mut mock_writer);
+        logger.log_u16_array(&[100u16, 250u16, 500u16]);
+        assert_eq!(mock_writer.get_string(), "[00100, 00250, 00500]");
     }
 }

--- a/libs/logging/src/lib.rs
+++ b/libs/logging/src/lib.rs
@@ -25,6 +25,36 @@ impl<'a> Logger<'a> {
             .unwrap();
         }
     }
+
+    pub fn log_u16(&mut self, val: &u16) {
+        for digit_index in (1..6).rev() {
+
+            // We have to temporarily convert the u16 to u32, otherwise doing 10⁶5 would cause an
+            // overflow in a u16 (100,000 > 65,535)
+            let digit = ((*val as u32 % 10u32.pow(digit_index as u32)) / 10u32.pow(digit_index as u32 - 1)) as u16;
+            let digit_character = digit + 48; // 48 is the offset of the numbers in the ASCII table
+
+            block!(match self.uart.bwrite_all(&[digit_character as u8]) {
+                Ok(_) => Ok(()),
+                Err(_) => Err(nb::Error::Other(())),
+            })
+            .unwrap();
+        }
+    }
+
+    pub fn log_u16_array(&mut self, array: &[u16]) {
+        self.log("[");
+
+        array.iter().enumerate().for_each(|(index, &value)| {
+            self.log_u16(&value);
+
+            if index != array.len() - 1 {
+                self.log(", ");
+            }
+        });
+
+        self.log("]");
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Added methods `log_u16` and `log_u16_array` to the `Logger` struct. This will be useful for debugging and getting data from the line follower later, such as displaying the values of the light sensor array.

The log_u16 method will print the value with all leading zeros.

Also added tests for these methods.