### PR TITLE
Make any motor go forward, no matter the side it is connected to

### DIFF
--- a/mightybuga_bsc/src/lib.rs
+++ b/mightybuga_bsc/src/lib.rs
@@ -159,11 +159,13 @@ impl Mightybuga_BSC {
             gpiob.pb5.into_push_pull_output(&mut gpiob.crl),
             gpioa.pa12.into_push_pull_output(&mut gpioa.crh),
             left_motor_channel,
+            true,
         );
         let motor_right = Motor::new(
             gpiob.pb9.into_push_pull_output(&mut gpiob.crh),
             gpiob.pb8.into_push_pull_output(&mut gpiob.crh),
             right_motor_channel,
+            false,
         );
 
         // Engine is the struct which contains all the logics regarding the motors


### PR DESCRIPTION
Added an `inverted` variable that reverts the movement of a motor, to fix the problem where you have to give the opposite instruction to one of the them.
This issue will probably be fixed in the hardware later, just making a temporary fix for now.